### PR TITLE
Remove broken net_graph command

### DIFF
--- a/playing.cfg
+++ b/playing.cfg
@@ -4,7 +4,6 @@ dota_minimap_always_draw_hero_icons 1
 dota_minimap_hero_size 700
 dota_minimap_rune_size 700
 fps_max 145
-net_graph 1
 fog_override 0
 dota_minimap_hero_scalar 1
 dota_minimap_hero_scalar_distance 20


### PR DESCRIPTION
When trying to set up my own instance of this I found the net_graph 1 command was throwing an error.

Looks like it's already replaced by dota_hud_netgraph 1 but the old one hadn't been removed